### PR TITLE
Add CocoaPods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Platform](https://img.shields.io/badge/Platform-iOS-lightgrey.svg?style=flat-square)](#prerequisites)
 [![Created](https://img.shields.io/badge/Made%20by-SumUp-blue.svg?style=flat-square)]()
 [![Supports](https://img.shields.io/badge/Requires-iOS%206+-red.svg?style=flat-square)]()
+[![CocoaPods compatible](https://img.shields.io/cocoapods/v/SumupSDK.svg?style=flat)](https://cocoapods.org/pods/SumupSDK)
 [![Version](https://img.shields.io/badge/Version-2.3-yellowgreen.svg?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-SumUp-brightgreen.svg?style=flat-square)](LICENSE)
 
@@ -33,7 +34,8 @@ For more information, please refer to SumUp's
 
 ### Table of Contents
 * [Installation](#installation)
-    * [Preparing your Xcode project](#preparing-your-xcode-project)
+    * [CocoaPods](#cocoapods)
+    * [Manual Installation](#manual-installation)
     * [Supported device orientation](#supported-device-orientation)
     * [Privacy Info plist keys](#privacy-info-plist-keys)
 * [Getting started](#getting-started)
@@ -47,7 +49,28 @@ For more information, please refer to SumUp's
 
 ## Installation
 
-### Preparing your Xcode project
+### CocoaPods
+
+CocoaPods is a dependency manager for Objective-C and Swift.
+To learn more about setting up your project for CocoaPods, please refer to the [official documentation](https://cocoapods.org/#install).
+To integrate SumUp SDK into your Xcode project using CocoaPods, you have to add it to your project's `Podfile`:
+
+```ruby
+platform :ios, '9.0'
+use_frameworks!
+
+target '<Your Target Name>' do
+  pod 'SumupSDK'
+end
+```
+
+Afterwards, run the following command:
+
+```bash
+$ pod install
+```
+
+### Manual Installation
 
 The SumUp SDK is provided as an embedded framework `SumupSDK.embeddedframework`
 that combines a static library, its headers and bundles containing resources such as
@@ -70,10 +93,10 @@ images and localizations. Please follow the steps below to prepare your project:
         SumupSDK.embeddedframework/Resources/YTLibResources.bundle
 
 
-> Note:  
+> Note:
 > You can use the [sample app](https://github.com/sumup/sumup-ios-sdk/tree/master/SumupSDKSampleApp)
 > that is provided with the SumUp SDK as a reference project.
-> The Xcode project contains sample apps written in Objective-C and Swift.  
+> The Xcode project contains sample apps written in Objective-C and Swift.
 > In your debug setup you can also call `+[SumupSDK testSDKIntegration]`.
 > It will run various checks and print its findings  to the console.
 > Please do not call it in your Release build.

--- a/SumupSDK.embeddedframework/SumupSDK.framework/Modules/module.modulemap
+++ b/SumupSDK.embeddedframework/SumupSDK.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module SumupSDK {
+    umbrella header "SumupSDK.h"
+    export *
+}

--- a/SumupSDK.podspec
+++ b/SumupSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name         = 'SumupSDK'
+  s.version      = '2.3'
+  s.summary      = 'Native iOS SDK for SumUp integration.'
+  s.description  = <<-DESC
+      Provides a native iOS SDK that enables you to integrate SumUp's proprietary
+       card terminal(s) and its payment platform to accept credit and debit card
+       payments (incl. VISA, MasterCard, American Express and more). SumUp's SDK
+       communicates transparently to the card terminal(s) via Bluetooth (BLE 4.0)
+       or an audio cable connection.
+                   DESC
+
+  s.homepage     = 'https://github.com/sumup/sumup-ios-sdk'
+  s.license      = { :type => 'Commercial', :file => 'LICENSE' }
+  s.author       = { 'SumUp' => 'integration@sumup.com' }
+
+  s.platform     = :ios, '6.0'
+  s.source       = { :git => 'https://github.com/sumup/sumup-ios-sdk.git', :tag => "v#{s.version}" }
+
+  s.frameworks   = 'Accelerate', 'AVFoundation', 'Foundation', 'MapKit', 'UIKit'
+
+  s.public_header_files = 'SumupSDK.embeddedframework/SumupSDK.framework/Versions/A/Headers/*.h'
+  s.source_files = 'SumupSDK.embeddedframework/SumupSDK.framework/Versions/A/Headers/*.h'
+  s.vendored_frameworks = 'SumupSDK.embeddedframework/SumupSDK.framework'
+  s.resources    = 'SumupSDK.embeddedframework/Resources/SMPSharedResources.bundle', 'SumupSDK.embeddedframework/Resources/YTLibResources.bundle'
+
+  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+end


### PR DESCRIPTION
This commit adds CocoaPods support to the SumUp SDK, making it easier to integrate SumUp into projects. It also contains a module map that allows you to use the SDK in your swift projects without the need for a bridging header. Simply `import SumupSDK` at the top of your Swift files.

If you want to test my branch, create a project and use the following compact Podfile:
```ruby
platform :ios, '9.0'
inhibit_all_warnings!

pod 'SumupSDK', :git => 'https://github.com/Building42/sumup-ios-sdk.git', :branch => 'feature-cocoapods'
target '<Your Target>'
```

The following steps are required for CocoaPods support: 
- Integrate the pull request
- Update the 2.3 tag to point to the latest commit (including the podspec)
- Check the podspec with `pod spec lint SumupSDK.podspec`
- If all is ok, submit it with `pod trunk push SumupSDK.podspec`

When you release a new version:
- Update the version in the podspec before tagging the new version
- Update CocoaPods with 'pod trunk push  SumupSDK.podspec`

For more information, have a look at [this guide](https://guides.cocoapods.org/making/specs-and-specs-repo.html)

This solves issue https://github.com/sumup/sumup-ios-sdk/issues/19.