### PR TITLE
Add Carthage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Version](https://img.shields.io/badge/Version-3.1-yellowgreen.svg?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-SumUp-brightgreen.svg?style=flat-square)](LICENSE)
 [![CocoaPods](https://img.shields.io/cocoapods/v/SumUpSDK.svg?style=flat-square)]()
+[![Carthage](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)]()
 
 This repository provides a native iOS SDK that enables you to integrate SumUp's proprietary
 card terminal(s) and its payment platform to accept credit and debit card payments
@@ -35,6 +36,7 @@ For more information, please refer to SumUp's
 * [Installation](#installation)
   * [Manual Integration](#manual-integration)
   * [Integration via CocoaPods](#integration-via-cocoapods)
+  * [Integration via Carthage](#integration-via-carthage)
   * [Supported device orientation](#supported-device-orientation)
   * [Privacy Info plist keys](#privacy-info-plist-keys)
 * [Getting started](#getting-started)
@@ -96,6 +98,21 @@ end
 ```
 
 To learn more about setting up your project for CocoaPods, please refer to the [official documentation](https://cocoapods.org/#install).
+
+### Integration via Carthage
+
+To integrate SumUp SDK into your Xcode project using Carthage, specify it in your `Cartfile`:
+
+```ogdl
+github "sumup/sumup-ios-sdk"
+```
+
+- Run `carthage update` to build the framework
+- Drag the `SumUp` framework into your Xcode project
+- Drag the `SMPSharedResources` resource bundle into your Xcode Project
+- Add the `carthage copy-frameworks` build phase script, see the [Carthage guide](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)
+- Add `$(SRCROOT)/Carthage/Build/iOS/SumUp.framework` to the script's Input Files
+- Add `$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SumUp.framework` to the script's Output Files
 
 ### Supported device orientation
 The SDK supports all device orientations on iPad and portrait on iPhone.

--- a/SumUp.xcodeproj/project.pbxproj
+++ b/SumUp.xcodeproj/project.pbxproj
@@ -1,0 +1,414 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		82B59342201BAA5B002088E4 /* SMPSharedResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 82B59340201BAA5B002088E4 /* SMPSharedResources.bundle */; };
+		82B59343201BAA5B002088E4 /* SumUpSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B59341201BAA5B002088E4 /* SumUpSDK.framework */; };
+		82C1BF761EDBD12A00D6EDB4 /* SumUp-Dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 82C1BF751EDBD12A00D6EDB4 /* SumUp-Dummy.m */; };
+		82C1BF8E1EDBDE4100D6EDB4 /* SumUp.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C1BF8B1EDBDCC300D6EDB4 /* SumUp.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C5936121F8CB6600316A35 /* SMPSkipScreenOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C5935A21F8CB6500316A35 /* SMPSkipScreenOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C5936221F8CB6600316A35 /* SMPSumUpSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C5935B21F8CB6500316A35 /* SMPSumUpSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C5936321F8CB6600316A35 /* SMPCheckoutRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C5935C21F8CB6500316A35 /* SMPCheckoutRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C5936421F8CB6600316A35 /* SumUpSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C5935D21F8CB6500316A35 /* SumUpSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C5936521F8CB6600316A35 /* SMPCheckoutResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C5935E21F8CB6500316A35 /* SMPCheckoutResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C5936621F8CB6600316A35 /* SMPMerchant.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C5935F21F8CB6600316A35 /* SMPMerchant.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C5936721F8CB6600316A35 /* SMPSumUpRegisterSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 82C5936021F8CB6600316A35 /* SMPSumUpRegisterSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		82B59340201BAA5B002088E4 /* SMPSharedResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = SMPSharedResources.bundle; sourceTree = "<group>"; };
+		82B59341201BAA5B002088E4 /* SumUpSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SumUpSDK.framework; sourceTree = "<group>"; };
+		82C1BF601EDBD08100D6EDB4 /* SumUp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SumUp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		82C1BF641EDBD08100D6EDB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		82C1BF751EDBD12A00D6EDB4 /* SumUp-Dummy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SumUp-Dummy.m"; sourceTree = "<group>"; };
+		82C1BF811EDBD3F400D6EDB4 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		82C1BF821EDBD3F400D6EDB4 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		82C1BF831EDBD3F400D6EDB4 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		82C1BF871EDBD4F600D6EDB4 /* SumUp.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SumUp.xcconfig; sourceTree = "<group>"; };
+		82C1BF881EDBD86200D6EDB4 /* SumUp.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = SumUp.modulemap; sourceTree = "<group>"; };
+		82C1BF8B1EDBDCC300D6EDB4 /* SumUp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SumUp.h; sourceTree = "<group>"; };
+		82C5935A21F8CB6500316A35 /* SMPSkipScreenOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMPSkipScreenOptions.h; sourceTree = "<group>"; };
+		82C5935B21F8CB6500316A35 /* SMPSumUpSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMPSumUpSDK.h; sourceTree = "<group>"; };
+		82C5935C21F8CB6500316A35 /* SMPCheckoutRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMPCheckoutRequest.h; sourceTree = "<group>"; };
+		82C5935D21F8CB6500316A35 /* SumUpSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SumUpSDK.h; sourceTree = "<group>"; };
+		82C5935E21F8CB6500316A35 /* SMPCheckoutResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMPCheckoutResult.h; sourceTree = "<group>"; };
+		82C5935F21F8CB6600316A35 /* SMPMerchant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMPMerchant.h; sourceTree = "<group>"; };
+		82C5936021F8CB6600316A35 /* SMPSumUpRegisterSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMPSumUpRegisterSDK.h; sourceTree = "<group>"; };
+		82C5936821F8CD0700316A35 /* ExternalAccessory.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ExternalAccessory.framework; path = System/Library/Frameworks/ExternalAccessory.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		82C1BF5C1EDBD08100D6EDB4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82B59343201BAA5B002088E4 /* SumUpSDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		82B5933E201BAA5B002088E4 /* SumUpSDK.embeddedframework */ = {
+			isa = PBXGroup;
+			children = (
+				82B5933F201BAA5B002088E4 /* Resources */,
+				82B59341201BAA5B002088E4 /* SumUpSDK.framework */,
+			);
+			path = SumUpSDK.embeddedframework;
+			sourceTree = "<group>";
+		};
+		82B5933F201BAA5B002088E4 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				82B59340201BAA5B002088E4 /* SMPSharedResources.bundle */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		82B59353201BAAA9002088E4 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				82C5935C21F8CB6500316A35 /* SMPCheckoutRequest.h */,
+				82C5935E21F8CB6500316A35 /* SMPCheckoutResult.h */,
+				82C5935F21F8CB6600316A35 /* SMPMerchant.h */,
+				82C5935A21F8CB6500316A35 /* SMPSkipScreenOptions.h */,
+				82C5936021F8CB6600316A35 /* SMPSumUpRegisterSDK.h */,
+				82C5935B21F8CB6500316A35 /* SMPSumUpSDK.h */,
+				82C5935D21F8CB6500316A35 /* SumUpSDK.h */,
+			);
+			name = Headers;
+			path = SumUpSDK.embeddedframework/SumUpSDK.framework/Versions/A/Headers;
+			sourceTree = SOURCE_ROOT;
+		};
+		82C1BF561EDBD08100D6EDB4 = {
+			isa = PBXGroup;
+			children = (
+				82C1BF621EDBD08100D6EDB4 /* SumUp */,
+				82B5933E201BAA5B002088E4 /* SumUpSDK.embeddedframework */,
+				82C1BF611EDBD08100D6EDB4 /* Products */,
+				82C1BF801EDBD3F400D6EDB4 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		82C1BF611EDBD08100D6EDB4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				82C1BF601EDBD08100D6EDB4 /* SumUp.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		82C1BF621EDBD08100D6EDB4 /* SumUp */ = {
+			isa = PBXGroup;
+			children = (
+				82B59353201BAAA9002088E4 /* Headers */,
+				82C1BF641EDBD08100D6EDB4 /* Info.plist */,
+				82C1BF8B1EDBDCC300D6EDB4 /* SumUp.h */,
+				82C1BF881EDBD86200D6EDB4 /* SumUp.modulemap */,
+				82C1BF871EDBD4F600D6EDB4 /* SumUp.xcconfig */,
+				82C1BF751EDBD12A00D6EDB4 /* SumUp-Dummy.m */,
+			);
+			path = SumUp;
+			sourceTree = "<group>";
+		};
+		82C1BF801EDBD3F400D6EDB4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				82C1BF811EDBD3F400D6EDB4 /* Accelerate.framework */,
+				82C1BF821EDBD3F400D6EDB4 /* AVFoundation.framework */,
+				82C5936821F8CD0700316A35 /* ExternalAccessory.framework */,
+				82C1BF831EDBD3F400D6EDB4 /* MapKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		82C1BF5D1EDBD08100D6EDB4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82C5936321F8CB6600316A35 /* SMPCheckoutRequest.h in Headers */,
+				82C5936521F8CB6600316A35 /* SMPCheckoutResult.h in Headers */,
+				82C5936621F8CB6600316A35 /* SMPMerchant.h in Headers */,
+				82C5936121F8CB6600316A35 /* SMPSkipScreenOptions.h in Headers */,
+				82C5936721F8CB6600316A35 /* SMPSumUpRegisterSDK.h in Headers */,
+				82C5936221F8CB6600316A35 /* SMPSumUpSDK.h in Headers */,
+				82C5936421F8CB6600316A35 /* SumUpSDK.h in Headers */,
+				82C1BF8E1EDBDE4100D6EDB4 /* SumUp.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		82C1BF5F1EDBD08100D6EDB4 /* SumUp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 82C1BF681EDBD08100D6EDB4 /* Build configuration list for PBXNativeTarget "SumUp" */;
+			buildPhases = (
+				82C1BF5B1EDBD08100D6EDB4 /* Sources */,
+				82C1BF5C1EDBD08100D6EDB4 /* Frameworks */,
+				82C1BF5D1EDBD08100D6EDB4 /* Headers */,
+				82C1BF5E1EDBD08100D6EDB4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SumUp;
+			productName = SumUp;
+			productReference = 82C1BF601EDBD08100D6EDB4 /* SumUp.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		82C1BF571EDBD08100D6EDB4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = SumUp;
+				TargetAttributes = {
+					82C1BF5F1EDBD08100D6EDB4 = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 82C1BF5A1EDBD08100D6EDB4 /* Build configuration list for PBXProject "SumUp" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 82C1BF561EDBD08100D6EDB4;
+			productRefGroup = 82C1BF611EDBD08100D6EDB4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				82C1BF5F1EDBD08100D6EDB4 /* SumUp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		82C1BF5E1EDBD08100D6EDB4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82B59342201BAA5B002088E4 /* SMPSharedResources.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		82C1BF5B1EDBD08100D6EDB4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82C1BF761EDBD12A00D6EDB4 /* SumUp-Dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		82C1BF661EDBD08100D6EDB4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		82C1BF671EDBD08100D6EDB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		82C1BF691EDBD08100D6EDB4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 82C1BF871EDBD4F600D6EDB4 /* SumUp.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 3.0;
+				DEFINES_MODULE = YES;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/SumupSDK.embeddedframework",
+					"$(PROJECT_DIR)/SumUpSDK.embeddedframework",
+				);
+				INFOPLIST_FILE = SumUp/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = $SRCROOT/SumUp/SumUp.modulemap;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sumup.SumUp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		82C1BF6A1EDBD08100D6EDB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 82C1BF871EDBD4F600D6EDB4 /* SumUp.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 3.0;
+				DEFINES_MODULE = YES;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/SumupSDK.embeddedframework",
+					"$(PROJECT_DIR)/SumUpSDK.embeddedframework",
+				);
+				INFOPLIST_FILE = SumUp/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = $SRCROOT/SumUp/SumUp.modulemap;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sumup.SumUp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		82C1BF5A1EDBD08100D6EDB4 /* Build configuration list for PBXProject "SumUp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				82C1BF661EDBD08100D6EDB4 /* Debug */,
+				82C1BF671EDBD08100D6EDB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		82C1BF681EDBD08100D6EDB4 /* Build configuration list for PBXNativeTarget "SumUp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				82C1BF691EDBD08100D6EDB4 /* Debug */,
+				82C1BF6A1EDBD08100D6EDB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 82C1BF571EDBD08100D6EDB4 /* Project object */;
+}

--- a/SumUp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SumUp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:SumUp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/SumUp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SumUp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SumUp.xcodeproj/xcshareddata/xcschemes/SumUp.xcscheme
+++ b/SumUp.xcodeproj/xcshareddata/xcschemes/SumUp.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82C1BF5F1EDBD08100D6EDB4"
+               BuildableName = "SumUp.framework"
+               BlueprintName = "SumUp"
+               ReferencedContainer = "container:SumUp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "82C1BF5F1EDBD08100D6EDB4"
+            BuildableName = "SumUp.framework"
+            BlueprintName = "SumUp"
+            ReferencedContainer = "container:SumUp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "82C1BF5F1EDBD08100D6EDB4"
+            BuildableName = "SumUp.framework"
+            BlueprintName = "SumUp"
+            ReferencedContainer = "container:SumUp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SumUp/Info.plist
+++ b/SumUp/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.1</string>
+	<key>CFBundleVersion</key>
+	<string>902</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/SumUp/SumUp-Dummy.m
+++ b/SumUp/SumUp-Dummy.m
@@ -1,0 +1,17 @@
+//
+//  Dummy.m
+//  SumupSDK
+//
+
+#import <Foundation/Foundation.h>
+#import <SumUpSDK/SumUpSDK.h>
+
+@interface SumUpDummy : NSObject
+@end
+
+@implementation SumUpDummy
+/// This dummy method is never called, but tells us if the embedded framework is properly linked.
+-(void)test {
+  [SMPSumUpSDK testSDKIntegration];
+}
+@end

--- a/SumUp/SumUp.h
+++ b/SumUp/SumUp.h
@@ -1,0 +1,19 @@
+//
+//  SumUp.h
+//  SumUp
+//
+
+#import <UIKit/UIKit.h>
+
+#import "SumUpSDK.h"
+#import "SMPCheckoutRequest.h"
+#import "SMPCheckoutResult.h"
+#import "SMPMerchant.h"
+#import "SMPSumUpRegisterSDK.h"
+#import "SMPSumUpSDK.h"
+
+//! Project version number for SumUp.
+FOUNDATION_EXPORT double SumUpVersionNumber;
+
+//! Project version string for SumUp.
+FOUNDATION_EXPORT const unsigned char SumUpVersionString[];

--- a/SumUp/SumUp.modulemap
+++ b/SumUp/SumUp.modulemap
@@ -1,0 +1,6 @@
+framework module SumUp {
+  umbrella header "SumUp.h"
+
+  export *
+  module * { export * }
+}

--- a/SumUp/SumUp.xcconfig
+++ b/SumUp/SumUp.xcconfig
@@ -1,0 +1,13 @@
+//
+//  SumupSDK.xcconfig
+//  SumupSDK
+//
+
+ENABLE_BITCODE = NO
+FRAMEWORK_SEARCH_PATHS = ${WRAP_FRAMEWORK_PATH}
+HEADER_SEARCH_PATHS = ${WRAP_FRAMEWORK_PATH}/Headers
+OTHER_CFLAGS = -isystem ${WRAP_FRAMEWORK_PATH}/Headers
+OTHER_LDFLAGS = ${WRAP_FLAGS}
+
+WRAP_FRAMEWORK_PATH = ${SRCROOT}/SumUpSDK.embeddedframework
+WRAP_FLAGS = -ObjC -framework Accelerate -framework AVFoundation -framework ExternalAccessory -framework MapKit -framework SumUpSDK


### PR DESCRIPTION
This commit adds Carthage support to the SumUp SDK, making it easier to integrate SumUp into projects. Carthage will build the shared scheme in the SumUp Xcode project, resulting in a framework wrapping the SumupSDK framework.

If you want to test my branch, create a project and use the following Cartfile:
```
github "Building42/sumup-ios-sdk" "feature-carthage"
```

**Note:** To use the framework in your project, write `import SumUp`. Unfortunately I couldn't name it `SumupSDK` because that would clash with the original framework.

The following steps are required for Carthage support:

- Integrate the pull request
- Update the 2.3 tag to point to the latest commit

When you release a new version:

- Update the version and build number in `SumUp/Info.plist`
- Drag any new headers in the SumUp Xcode project, be sure to set them to Public

This solves issue https://github.com/sumup/sumup-ios-sdk/issues/37.